### PR TITLE
Add Support for 'extra' key

### DIFF
--- a/flojoy/data_container.py
+++ b/flojoy/data_container.py
@@ -171,7 +171,6 @@ class DataContainer(Box):
             self.__check_for_missing_keys(splitted_type, keys)
         else:
             for k in self.type_keys_map[dc_type]:
-                print(" checking: ", k, " with: ", keys)
                 if k not in keys:
                     raise KeyError(f'"{k}" key must be provided for type "{dc_type}"')
 

--- a/flojoy/flojoy_python.py
+++ b/flojoy/flojoy_python.py
@@ -94,11 +94,19 @@ def get_redis_obj(id: str) -> dict[str, Any]:
     return parse_obj
 
 
-def try_parse_array(arr: List[str], t: Type) -> Optional[List[Any]]:
-    try:
-        return list(map(t, arr))
-    except:
-        return None
+def parse_array(str_value: str) -> List[Union[int, float, str]]:
+    if not str_value:
+        return []
+
+    val_list = [val.strip() for val in str_value.split(",")]
+    # First try to cast into int, then float, then keep as string if all else fails
+    for t in [int, float, str]:
+        try:
+            val = list(map(t, val_list))
+            break
+        except Exception:
+            continue
+    return val
 
 
 ParamValTypes = Literal[
@@ -110,18 +118,8 @@ def format_param_value(value: Any, value_type: ParamValTypes):
     match value_type:
         case "array":
             s = str(value)
-            if not s:
-                return []
-
-            vals = [val.strip() for val in s.split(",") if val.strip()]
-            # First try to cast into int, then float, then keep as string if all else fails
-            arr = try_parse_array(vals, int)
-            if arr:
-                return arr
-            arr = try_parse_array(vals, float)
-            if arr:
-                return arr
-            return vals
+            parsed_value = parse_array(s)
+            return parsed_value
         case "float":
             return float(value)
         case "int":

--- a/flojoy/utils.py
+++ b/flojoy/utils.py
@@ -10,6 +10,7 @@ from typing import Union, Any
 import requests
 from redis import Redis
 from dotenv import dotenv_values  # type:ignore
+import difflib
 
 
 env_vars = dotenv_values("../.env")
@@ -23,6 +24,14 @@ redis_instance = Redis(host=REDIS_HOST, port=int(REDIS_PORT))
 def send_to_socket(data: str):
     print("posting data to socket:", f"{BACKEND_URL}/worker_response")
     requests.post(f"{BACKEND_URL}/worker_response", json=data)
+
+
+def find_closest_match(given_str: str, available_str: list[str]):
+    closest_match = difflib.get_close_matches(given_str, available_str, n=1)
+    if closest_match:
+        return closest_match[0]
+    else:
+        return None
 
 
 class PlotlyJSONEncoder(_json.JSONEncoder):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name="flojoy",
     packages=["flojoy"],
-    version="0.1.4-dev1",
+    version="0.1.4-dev3",
     license="MIT",
     description="Python client library for Flojoy.",
     author="flojoy",


### PR DESCRIPTION
### Changes:
- Now any extra resources can be passed to `DataContainer` class with help of `extra` key. Such as:
```python
   dc = DataContainer(type='dataframe', m=df, extra={})
```
- Added the closest suggestion for misspelled types like "Did you mean: grayscale ? "