### PR TITLE
#529 Allow nodes to declare their inputs and params as regular function parameters

### DIFF
--- a/flojoy/flojoy_python.py
+++ b/flojoy/flojoy_python.py
@@ -14,6 +14,8 @@ from networkx.drawing.nx_pylab import draw as nx_draw  # type: ignore
 from typing import Union, cast, Any, Literal, Callable, List, Optional, Type
 from .job_result_utils import get_frontend_res_obj_from_result, get_dc_from_result
 from .utils import redis_instance, send_to_socket
+from inspect import signature
+import os
 
 
 def get_flojoy_root_dir() -> str:
@@ -50,27 +52,34 @@ def get_parameter_manifest() -> dict[str, Any]:
 
 
 def fetch_inputs(
-    previous_job_ids: list[str], mock: bool = False
+    previous_jobs: list[dict[str, str]], mock: bool = False
 ) -> list[DataContainer]:
     """
     Queries Redis for job results
 
     Parameters
     ----------
-    previous_job_ids : list of Redis job IDs that directly precede this node
+    previous_jobs : list of Redis jobs that directly precede this node.
+    Each item representing a job contains `job_id` and `input_name`.
+    `input_name` is the port where the previous job with `job_id` connects to.
 
     Returns
     -------
     inputs : list of DataContainer objects
     """
-    if mock is True:
-        return [DataContainer(x=np.linspace(0, 10, 100))]
-
     inputs: list[DataContainer] = []
+    dict_inputs: dict[str, DataContainer] = dict()
 
     try:
-        for prev_job_id in previous_job_ids:
-            print("fetching input from prev job id:", prev_job_id)
+        for prev_job in previous_jobs:
+            prev_job_id = prev_job.get("job_id")
+            input_name = prev_job.get("input_name")
+            print(
+                "fetching input from prev job id:",
+                prev_job_id,
+                " for input:",
+                input_name,
+            )
             job = Job.fetch(prev_job_id, connection=redis_instance)  # type:ignore
             job_result: dict[str, Any] = job.result  # type:ignore
             result = get_dc_from_result(job_result)
@@ -82,10 +91,11 @@ def fetch_inputs(
             )
             if result is not None:
                 inputs.append(result)
+                dict_inputs[input_name] = result
     except Exception:
         print(traceback.format_exc())
 
-    return inputs
+    return inputs, dict_inputs
 
 
 def get_redis_obj(id: str) -> dict[str, Any]:
@@ -184,8 +194,7 @@ def flojoy(func: Callable[..., DataContainer | dict[str, Any]]):
         job_id = cast(str, kwargs["job_id"])
         jobset_id = cast(str, kwargs["jobset_id"])
         try:
-            mock = False
-            previous_job_ids = cast(list[str], kwargs.get("previous_job_ids", []))
+            previous_jobs = cast(list[dict[str, str]], kwargs.get("previous_jobs", []))
             ctrls = cast(
                 Union[dict[str, dict[str, str]], None], kwargs.get("ctrls", None)
             )
@@ -229,12 +238,19 @@ def flojoy(func: Callable[..., DataContainer | dict[str, Any]]):
             func_params["node_id"] = node_id
             func_params["job_id"] = job_id
 
-            print("executing node_id:", node_id, "previous_job_ids:", previous_job_ids)
+            print("executing node_id:", node_id, "previous_jobs:", previous_jobs)
             print(node_id, " params: ", json.dumps(func_params, indent=2))
-            node_inputs = fetch_inputs(previous_job_ids, mock)
+            node_inputs, dict_inputs = fetch_inputs(previous_jobs)
 
             # running the node
-            dc_obj = func(node_inputs, func_params)  # DataContainer object from node
+            sig = signature(func)
+            args = {}
+            if len(sig.parameters) > 2:
+                args["dict_inputs"] = dict_inputs
+
+            dc_obj = func(
+                node_inputs, func_params, **args
+            )  # DataContainer object from node
             if isinstance(
                 dc_obj, DataContainer
             ):  # some special nodes like LOOP return dict instead of `DataContainer`
@@ -242,6 +258,7 @@ def flojoy(func: Callable[..., DataContainer | dict[str, Any]]):
             result = get_frontend_res_obj_from_result(
                 dc_obj
             )  # Response object to send to FE
+
             send_to_socket(
                 json.dumps(
                     {

--- a/flojoy/flojoy_python.py
+++ b/flojoy/flojoy_python.py
@@ -246,32 +246,24 @@ def flojoy(func: Callable[..., DataContainer | dict[str, Any]]):
             print(f"constructing inputs for {func}")
             args = {}
             sig = signature(func)
-            for key in sig.parameters.keys():
-                param = sig.parameters[key]
-                print(f"type for key: {key}", param.annotation)
-                if str(param.annotation) == "list[flojoy.data_container.DataContainer]":
-                    print(
-                        f"{key} is a list of data containers, passing all DataContainers into it"
-                    )
-                    args[key] = node_inputs
-                elif (
-                    str(param.annotation)
-                    == "<class 'flojoy.data_container.DataContainer'>"
-                ):
-                    print(
-                        f"{key} is a data container, check input exists?: {key in dict_inputs}"
-                    )
-                    args[key] = dict_inputs.get(key, None)
-                elif str(param.annotation) == "<class 'dict'>":
-                    print(
-                        f"{key} is a dictionary of params, passing all params into it"
-                    )
-                    args[key] = func_params
-                else:
-                    print(
-                        f"{key} is a param, check param exists?: {key in func_params}"
-                    )
-                    args[key] = func_params.get(key, None)
+
+            # once all the nodes are migrated to the new node api, remove the if condition
+            keys = list(sig.parameters)
+            if (
+                len(sig.parameters) == 2
+                and sig.parameters[keys[0]].annotation == list[DataContainer]
+            ):
+                args[keys[0]] = node_inputs
+            else:
+                args = {**args, **dict_inputs}
+
+            # once all the nodes are migrated to the new node api, remove the if condition
+            if len(sig.parameters) == 2 and sig.parameters[keys[1]].annotation == dict:
+                args[keys[1]] = func_params
+            else:
+                for param, value in func_params.items():
+                    if param in sig.parameters:
+                        args[param] = value
 
             print("calling node with args keys:", args.keys())
 


### PR DESCRIPTION
### Why is this change needed?
Currently a node receives its inputs as an array. It's been reported that the ordering of inputs do not stay fixed. We need a way for nodes to identify inputs by their name.

### What is the solution implemented?
This PR add support for nodes to receive inputs and params as regular python function parameters.

It achieves it by utilizing the type hints of the function parameters. For example, the SINE node can be changed 
from:
```
def SINE(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
```
to:
```
def SINE(default: DataContainer, waveform: str, amplitude: float, frequency: float, offset: float, phase: float) -> DataContainer:
```

### How was this change tested?
On my local machine, I ran the default app with the modified version of the SINE node. It is working. See the screenshot below for the console printouts of how the inputs and params are being processed.

<img width="1286" alt="Screenshot 2023-06-15 at 10 31 42 PM" src="https://github.com/flojoy-io/python/assets/100451944/3736ec33-7fc7-41ae-9fdb-0e40cc61ca77">


### Note
- The change is backward compatible, meaning the old style node signature will still work which should allow us to migrate incrementally.
- To be able to write node function as regular python function, this PR has to be merged first https://github.com/flojoy-io/studio/pull/556

**Issue:** https://github.com/flojoy-io/studio/issues/529