### PR TITLE
Add thin wrapper to use and manage HuggingFace hub models

### DIFF
--- a/flojoy/hflib/hub_models/__init__.py
+++ b/flojoy/hflib/hub_models/__init__.py
@@ -1,0 +1,59 @@
+from abc import ABCMeta, abstractmethod
+from enum import Enum
+from typing import Any
+
+
+class HubModel(metaclass=ABCMeta):
+    @abstractmethod
+    def download_and_cache(self) -> None:
+        pass
+
+    @property
+    @abstractmethod 
+    def cached(self) -> bool:
+        pass
+
+    @abstractmethod
+    def _get_executable_model(self) -> Any:
+        pass
+
+    def get_executable_model(self) -> Any:
+        if(not self.cached):
+            raise ValueError("Model not cached. Call download_and_cache() first.")
+        return self._get_executable_model()
+
+
+class HubModelFactory:
+    """Factory class for HuggingFace hub models
+
+    Example usage:
+
+    ```python
+    from flojoy.hflib.hub_models import HubModelFactory, ImageCaptionModels
+
+    factory = HubModelFactory()
+    hub_model = factory.create_model(ImageCaptionModels.NLP_CONNECT_VIT_GPT2)
+    # m
+    
+    """
+    _creators = {}
+
+    @classmethod
+    def register(cls, model_type: Enum):
+        def decorator(creator_class):
+            if model_type in cls._creators:
+                raise Exception(f"Model type {model_type} already registered.")
+            cls._creators[model_type] = creator_class
+            return creator_class
+        return decorator
+
+    @classmethod
+    def create_model(cls, model_type: Enum):
+        if model_type not in cls._creators:
+            raise ValueError(f"Invalid model type: {model_type}")
+        return cls._creators[model_type]()
+    
+
+from .image_caption import (
+    ImageCaptionModels
+)

--- a/flojoy/hflib/hub_models/__init__.py
+++ b/flojoy/hflib/hub_models/__init__.py
@@ -9,7 +9,7 @@ class HubModel(metaclass=ABCMeta):
         pass
 
     @property
-    @abstractmethod 
+    @abstractmethod
     def cached(self) -> bool:
         pass
 
@@ -18,7 +18,7 @@ class HubModel(metaclass=ABCMeta):
         pass
 
     def get_executable_model(self) -> Any:
-        if(not self.cached):
+        if not self.cached:
             raise ValueError("Model not cached. Call download_and_cache() first.")
         return self._get_executable_model()
 
@@ -39,6 +39,7 @@ class HubModelFactory:
     ```
 
     """
+
     _creators = {}
 
     @classmethod
@@ -48,6 +49,7 @@ class HubModelFactory:
                 raise Exception(f"Model type {model_type} already registered.")
             cls._creators[model_type] = creator_class
             return creator_class
+
         return decorator
 
     @classmethod
@@ -55,8 +57,6 @@ class HubModelFactory:
         if model_type not in cls._creators:
             raise ValueError(f"Invalid model type: {model_type}")
         return cls._creators[model_type]()
-    
 
-from .image_caption import (
-    ImageCaptionModels
-)
+
+from .image_caption import ImageCaptionModels

--- a/flojoy/hflib/hub_models/__init__.py
+++ b/flojoy/hflib/hub_models/__init__.py
@@ -33,8 +33,11 @@ class HubModelFactory:
 
     factory = HubModelFactory()
     hub_model = factory.create_model(ImageCaptionModels.NLP_CONNECT_VIT_GPT2)
-    # m
-    
+    hub_model.download_and_cache() # Download the model and cache it locally
+    model = hub_model.get_executable_model() # Get the executable model
+    # Do work
+    ```
+
     """
     _creators = {}
 

--- a/flojoy/hflib/hub_models/image_caption.py
+++ b/flojoy/hflib/hub_models/image_caption.py
@@ -20,11 +20,17 @@ class NLPConnectVitGPT2(HubModel):
     def __init__(self):
         self._model, self._feature_extractor, self._tokenizer = None, None, None
         self._cached = False
-    
+
     def download_and_cache(self):
-        self._model = ts.VisionEncoderDecoderModel.from_pretrained("nlpconnect/vit-gpt2-image-captioning", revision="dc68f91")
-        self._feature_extractor = ts.ViTImageProcessor.from_pretrained("nlpconnect/vit-gpt2-image-captioning", revision="dc68f91")
-        self._tokenizer = ts.AutoTokenizer.from_pretrained("nlpconnect/vit-gpt2-image-captioning", revision="dc68f91")
+        self._model = ts.VisionEncoderDecoderModel.from_pretrained(
+            "nlpconnect/vit-gpt2-image-captioning", revision="dc68f91"
+        )
+        self._feature_extractor = ts.ViTImageProcessor.from_pretrained(
+            "nlpconnect/vit-gpt2-image-captioning", revision="dc68f91"
+        )
+        self._tokenizer = ts.AutoTokenizer.from_pretrained(
+            "nlpconnect/vit-gpt2-image-captioning", revision="dc68f91"
+        )
         self._cached = True
 
     @property
@@ -32,4 +38,8 @@ class NLPConnectVitGPT2(HubModel):
         return self._cached
 
     def _get_executable_model(self) -> ImageCaptionModel:
-        return ImageCaptionModel(model=self._model, feature_extractor=self._feature_extractor, tokenizer=self._tokenizer)
+        return ImageCaptionModel(
+            model=self._model,
+            feature_extractor=self._feature_extractor,
+            tokenizer=self._tokenizer,
+        )

--- a/flojoy/hflib/hub_models/image_caption.py
+++ b/flojoy/hflib/hub_models/image_caption.py
@@ -22,9 +22,9 @@ class NLPConnectVitGPT2(HubModel):
         self._cached = False
     
     def download_and_cache(self):
-        self._model = ts.VisionEncoderDecoderModel.from_pretrained("nlpconnect/vit-gpt2-image-captioning")
-        self._feature_extractor = ts.ViTImageProcessor.from_pretrained("nlpconnect/vit-gpt2-image-captioning")
-        self._tokenizer = ts.AutoTokenizer.from_pretrained("nlpconnect/vit-gpt2-image-captioning")
+        self._model = ts.VisionEncoderDecoderModel.from_pretrained("nlpconnect/vit-gpt2-image-captioning", revision="dc68f91")
+        self._feature_extractor = ts.ViTImageProcessor.from_pretrained("nlpconnect/vit-gpt2-image-captioning", revision="dc68f91")
+        self._tokenizer = ts.AutoTokenizer.from_pretrained("nlpconnect/vit-gpt2-image-captioning", revision="dc68f91")
         self._cached = True
 
     @property

--- a/flojoy/hflib/hub_models/image_caption.py
+++ b/flojoy/hflib/hub_models/image_caption.py
@@ -1,0 +1,35 @@
+from enum import Enum, auto
+from typing import NamedTuple
+import transformers as ts
+
+from ..hub_models import HubModel, HubModelFactory
+
+
+class ImageCaptionModels(Enum):
+    NLP_CONNECT_VIT_GPT2 = auto()
+
+
+class ImageCaptionModel(NamedTuple):
+    model: ts.VisionEncoderDecoderModel
+    feature_extractor: ts.ViTImageProcessor
+    tokenizer: ts.AutoTokenizer
+
+
+@HubModelFactory.register(ImageCaptionModels.NLP_CONNECT_VIT_GPT2)
+class NLPConnectVitGPT2(HubModel):
+    def __init__(self):
+        self._model, self._feature_extractor, self._tokenizer = None, None, None
+        self._cached = False
+    
+    def download_and_cache(self):
+        self._model = ts.VisionEncoderDecoderModel.from_pretrained("nlpconnect/vit-gpt2-image-captioning")
+        self._feature_extractor = ts.ViTImageProcessor.from_pretrained("nlpconnect/vit-gpt2-image-captioning")
+        self._tokenizer = ts.AutoTokenizer.from_pretrained("nlpconnect/vit-gpt2-image-captioning")
+        self._cached = True
+
+    @property
+    def cached(self) -> bool:
+        return self._cached
+
+    def _get_executable_model(self) -> ImageCaptionModel:
+        return ImageCaptionModel(model=self._model, feature_extractor=self._feature_extractor, tokenizer=self._tokenizer)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name="flojoy",
-    packages=["flojoy"],
+    packages=find_packages(exclude=["tests"]),
     version="0.1.4-dev5",
     license="MIT",
     description="Python client library for Flojoy.",

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "scheduler",
         "topic",
     ],
+    python_requires=">=3.10",
     install_requires=[
         "python-box",
         "requests",
@@ -31,6 +32,10 @@ setup(
         "python-dotenv",
         "pyyaml",
         "plotly==5.8.2",
+        "transformers>=4.26.0",
+        "torch>=1.9",
+        "torchvision>=0.10",
+        "Pillow",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
- Add `hflib` to download, cache and execute AI models from within Flojoy nodes
- Add `hflib` dependencies to `setup.py`
- Add `python>=3.10` requirement to `setup.py` since I noticed we use a lot of python >=3.10 syntax in the code already
- Use `find_packages` in `setup.py` to support child packages within `flojoy`

Example usage of `hflib`

  ```python
  from flojoy.hflib.hub_models import HubModelFactory, ImageCaptionModels

  factory = HubModelFactory()
  hub_model = factory.create_model(ImageCaptionModels.NLP_CONNECT_VIT_GPT2)
  hub_model.download_and_cache() # Download the model and cache it locally
  model = hub_model.get_executable_model() # Get the executable model
  # Do work
  ```