### PR TITLE
Add `@run_in_venv` decorator, allow to run functions in separate virtual environments

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,4 +30,4 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run python tests
-        run: pytest
+        run: pytest -vv --ignore tests/flojoy_node_venv_test_.py

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,4 +30,4 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run python tests
-        run: pytest -vv --ignore tests/flojoy_node_venv_test_.py
+        run: pytest

--- a/.github/workflows/test-flojoy-node-env.yaml
+++ b/.github/workflows/test-flojoy-node-env.yaml
@@ -1,4 +1,4 @@
-name: Pytest
+name: Test flojoy_node_env
 
 # Trigger on push if flojoy_node_env.py is modified
 # for any branch

--- a/.github/workflows/test-flojoy-node-env.yaml
+++ b/.github/workflows/test-flojoy-node-env.yaml
@@ -28,7 +28,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run python tests
-        run: pytest -vv tests/flojoy_node_venv_test_.py 
+        run: python -m pytest -vv tests/flojoy_node_venv_test_.py 
     
   pytest-macos:
     runs-on: macos-latest
@@ -47,7 +47,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run python tests
-        run: pytest -vv tests/flojoy_node_venv_test_.py 
+        run: python -m pytest -vv tests/flojoy_node_venv_test_.py 
   
   pytest-windows:
     runs-on: windows-latest
@@ -68,7 +68,7 @@ jobs:
         shell: powershell
 
       - name: Run python tests
-        run: pytest -vv tests/flojoy_node_venv_test_.py 
+        run: python -m pytest -vv tests/flojoy_node_venv_test_.py 
         shell: powershell
   
 

--- a/.github/workflows/test-flojoy-node-env.yaml
+++ b/.github/workflows/test-flojoy-node-env.yaml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  pytest-ubuntu:
+  ubuntu:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
       - name: Run python tests
         run: python -m pytest -vv tests/flojoy_node_venv_test_.py 
     
-  pytest-macos:
+  macos:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -57,7 +57,7 @@ jobs:
       - name: Run python tests
         run: python -m pytest -vv tests/flojoy_node_venv_test_.py 
   
-  pytest-windows:
+  windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-flojoy-node-env.yaml
+++ b/.github/workflows/test-flojoy-node-env.yaml
@@ -5,9 +5,12 @@ name: Test flojoy_node_env
 
 on:
   push:
+    branches:
+      - "main"
     paths:
       - "flojoy/flojoy_node_env.py"
       - "tests/flojoy_node_venv_test_.py"
+  
   pull_request:
     paths:
       - "flojoy/flojoy_node_env.py"

--- a/.github/workflows/test-flojoy-node-env.yaml
+++ b/.github/workflows/test-flojoy-node-env.yaml
@@ -1,9 +1,12 @@
 name: Pytest
 
 # Trigger on push if flojoy_node_env.py is modified
+# for any branch
 
 on:
   push:
+    branches:
+      - "*"
     paths:
       - "flojoy/flojoy_node_env.py"
       - "tests/flojoy_node_venv_test_.py"

--- a/.github/workflows/test-flojoy-node-env.yaml
+++ b/.github/workflows/test-flojoy-node-env.yaml
@@ -33,7 +33,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run python tests
-        run: python -m pytest -vv tests/flojoy_node_venv_test_.py 
+        run: python -m pytest -vv tests/flojoy_node_venv_test_.py --runslow  
     
   macos:
     runs-on: macos-latest
@@ -52,7 +52,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run python tests
-        run: python -m pytest -vv tests/flojoy_node_venv_test_.py 
+        run: python -m pytest -vv tests/flojoy_node_venv_test_.py --runslow  
   
   windows:
     runs-on: windows-latest
@@ -73,7 +73,7 @@ jobs:
         shell: powershell
 
       - name: Run python tests
-        run: python -m pytest -vv tests/flojoy_node_venv_test_.py 
+        run: python -m pytest -vv tests/flojoy_node_venv_test_.py --runslow  
         shell: powershell
   
 

--- a/.github/workflows/test-flojoy-node-env.yaml
+++ b/.github/workflows/test-flojoy-node-env.yaml
@@ -1,8 +1,5 @@
 name: Test flojoy_node_env
 
-# Trigger on push if flojoy_node_env.py is modified
-# for any branch
-
 on:
   push:
     branches:

--- a/.github/workflows/test-flojoy-node-env.yaml
+++ b/.github/workflows/test-flojoy-node-env.yaml
@@ -5,8 +5,10 @@ name: Test flojoy_node_env
 
 on:
   push:
-    branches:
-      - "*"
+    paths:
+      - "flojoy/flojoy_node_env.py"
+      - "tests/flojoy_node_venv_test_.py"
+  pull_request:
     paths:
       - "flojoy/flojoy_node_env.py"
       - "tests/flojoy_node_venv_test_.py"

--- a/.github/workflows/test-flojoy-node-env.yaml
+++ b/.github/workflows/test-flojoy-node-env.yaml
@@ -1,0 +1,75 @@
+name: Pytest
+
+# Trigger on push if flojoy_node_env.py is modified
+
+on:
+  push:
+    paths:
+      - "flojoy/flojoy_node_env.py"
+      - "tests/flojoy_node_venv_test_.py"
+    
+  workflow_dispatch:
+
+jobs:
+  pytest-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - name: Install pip dependencies
+        run: |
+          pip install ruff pytest
+          pip install -r requirements.txt
+
+      - name: Run python tests
+        run: pytest -vv tests/flojoy_node_venv_test_.py 
+    
+  pytest-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - name: Install pip dependencies
+        run: |
+          pip install ruff pytest
+          pip install -r requirements.txt
+
+      - name: Run python tests
+        run: pytest -vv tests/flojoy_node_venv_test_.py 
+  
+  pytest-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install pip dependencies
+        run: |
+          pip install ruff pytest
+          pip install -r requirements.txt
+        shell: powershell
+
+      - name: Run python tests
+        run: pytest -vv tests/flojoy_node_venv_test_.py 
+        shell: powershell
+  
+
+

--- a/flojoy/__init__.py
+++ b/flojoy/__init__.py
@@ -9,3 +9,4 @@ from .data_container import *
 from .utils import *
 from .parameter_types import *
 from .small_memory import *
+from .flojoy_node_venv import *

--- a/flojoy/__init__.py
+++ b/flojoy/__init__.py
@@ -9,9 +9,6 @@ from .data_container import *
 from .utils import *
 from .parameter_types import *
 from .small_memory import *
-<<<<<<< HEAD
 from .flojoy_node_venv import *
-=======
 from .job_service import *
 from .node_init import *
->>>>>>> origin/new-node-api

--- a/flojoy/__init__.pyi
+++ b/flojoy/__init__.pyi
@@ -10,12 +10,9 @@ from .data_container import *
 from .utils import *
 from .parameter_types import *
 from .small_memory import *
-<<<<<<< HEAD
 from .flojoy_node_venv import *
-=======
 from .job_service import *
 from .node_init import *
->>>>>>> origin/new-node-api
 
 def flojoy(
     original_function: Callable[..., DataContainer | dict[str, Any] | TypedDict]

--- a/flojoy/__init__.pyi
+++ b/flojoy/__init__.pyi
@@ -10,6 +10,7 @@ from .data_container import *
 from .utils import *
 from .parameter_types import *
 from .small_memory import *
+from .flojoy_node_venv import *
 
 def flojoy(
     original_function: Callable[..., DataContainer | dict[str, Any] | TypedDict]

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -39,12 +39,16 @@ class MultiprocessingExecutableContextManager:
     def __init__(self, executable_path):
         self.original_executable_path = sys.executable
         self.executable_path = executable_path
+        # We need to save the original start method 
+        # because it is set to "fork" by default on Linux while we ALWAYS want spawn
+        self.original_start_method = multiprocessing.get_start_method()
 
     def __enter__(self):
-        self.original_start_method = multiprocessing.get_start_method()
         multiprocessing.set_executable(self.executable_path)
+        multiprocessing.set_start_method("spawn")
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        multiprocessing.set_start_method(self.original_start_method)
         multiprocessing.set_executable(self.original_executable_path)
 
 class SwapSysPath:

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -44,11 +44,13 @@ class MultiprocessingExecutableContextManager:
         self.original_start_method = multiprocessing.get_start_method()
 
     def __enter__(self):
+        if(self.original_start_method != "spawn"):
+            multiprocessing.set_start_method("spawn", force=True)
         multiprocessing.set_executable(self.executable_path)
-        multiprocessing.set_start_method("spawn")
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        multiprocessing.set_start_method(self.original_start_method)
+        if(self.original_start_method != "spawn"):
+            multiprocessing.set_start_method(self.original_start_method, force=True)
         multiprocessing.set_executable(self.original_executable_path)
 
 class SwapSysPath:

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -22,6 +22,7 @@ def TORCH_NODE(default: Matrix) -> Matrix:
 import hashlib
 import os
 import importlib.metadata
+import shutil
 import sys
 import subprocess
 import multiprocessing
@@ -114,10 +115,15 @@ def run_in_venv(pip_dependencies=[]):
         venv.create(venv_path, with_pip=True)
         # Install the pip dependencies into the virtual environment
         if pip_dependencies:
-            _install_pip_dependencies(
-                venv_executable=venv_executable,
-                pip_dependencies=tuple(pip_dependencies)
-            )
+            try:
+                _install_pip_dependencies(
+                    venv_executable=venv_executable,
+                    pip_dependencies=tuple(pip_dependencies)
+                )
+            except subprocess.CalledProcessError as e:
+                shutil.rmtree(venv_path)
+                raise e
+
     # Define the decorator
     def decorator(func):
         @wraps(func)

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -1,0 +1,142 @@
+"""
+This module provides a decorator that allows a function to be executed in a virtual environment.
+The decorator will create a virtual environment if it does not exist, and install the pip dependencies
+specified in the decorator arguments. The decorator will also install the pip dependencies if the
+virtual environment exists but does not contain the pip dependencies.
+
+Example usage:
+
+```python
+from flojoy import flojoy, run_in_venv
+
+@flojoy
+@run_in_venv(pip_dependencies=["torch==2.0.1", "torchvision==0.15.2"])
+def TORCH_NODE(default: Matrix) -> Matrix:
+    import torch
+    import torchvision
+    # Do stuff with torch
+    ...
+    return Matrix(...)
+
+"""
+import hashlib
+import os
+import sys
+import subprocess
+import multiprocessing
+import cloudpickle
+import tempfile
+import venv
+from functools import  wraps
+
+
+__all__ = ["run_in_venv"]
+
+class MultiprocessingExecutableContextManager:
+    """Temporarily change the executable used by multiprocessing."""
+    def __init__(self, executable_path):
+        self.original_executable_path = sys.executable
+        self.executable_path = executable_path
+
+    def __enter__(self):
+        self.original_start_method = multiprocessing.get_start_method()
+        multiprocessing.set_executable(self.executable_path)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        multiprocessing.set_executable(self.original_executable_path)
+
+class SwapSysPath:
+    """Temporarily swap the sys.path of the child process with the sys.path of the parent process."""
+    def __init__(self, venv_executable):
+        self.new_path = _get_venv_syspath(venv_executable)
+        self.old_path = None
+
+    def __enter__(self):
+        self.old_path = sys.path
+        sys.path = self.new_path
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        sys.path = self.old_path
+
+
+def _install_pip_dependencies(
+        venv_executable: os.PathLike,
+        pip_dependencies: tuple[str],
+        verbose: bool = False
+    ):
+    """Install pip dependencies into the virtual environment."""
+    command = [venv_executable, "-m", "pip", "install"]
+    if(not verbose):
+        command += ["-q"]  
+    command += list(pip_dependencies)
+    subprocess.check_call(command)
+
+def _get_venv_syspath(venv_executable: os.PathLike) -> list[str]:
+    """Get the sys.path of the virtual environment."""
+    command = [venv_executable, "-c", "import sys\nprint(sys.path)"]
+    cmd_output = subprocess.run(command, check=True, capture_output=True, text=True)
+    return eval(cmd_output.stdout)
+
+class PickleableFunctionWithPipeIO:
+    """A wrapper for a function that can be pickled and executed in a child process."""
+    def __init__(self, func, child_conn, venv_executable):
+        self._func_serialized = cloudpickle.dumps(func)
+        self._child_conn = child_conn
+        self._venv_executable = venv_executable
+
+    def __call__(self, *args, **kwargs):
+        fn = cloudpickle.loads(self._func_serialized)
+        args = [cloudpickle.loads(arg) for arg in args]
+        kwargs = {key: cloudpickle.loads(value) for key, value in kwargs.items()}
+        with SwapSysPath(venv_executable=self._venv_executable):
+            result = fn(*args, **kwargs)
+        self._child_conn.send(result)
+
+def run_in_venv(pip_dependencies=[]):
+    # Pre-pend flojoy and cloudpickle as mandatory pip dependencies
+    pip_dependencies = sorted(["flojoy", "cloudpickle"] + pip_dependencies)
+    # Get the system's temporary directory path
+    temp_dirpath = tempfile.gettempdir()
+    # Generate a path-safe hash of the pip dependencies
+    # this prevents the duplication of virtual environments
+    pip_dependencies_hash = hashlib.sha256("".join(pip_dependencies).encode()).hexdigest()
+    venv_path = os.path.join(temp_dirpath, f"flojoy_node_venv_{pip_dependencies_hash}")
+    venv_executable = os.path.join(venv_path, "bin", "python")
+    # Create the node_env virtual environment if it does not exist
+    if not os.path.exists(venv_path):
+        venv.create(venv_path, with_pip=True)
+    # Install the pip dependencies into the virtual environment
+    if pip_dependencies:
+        _install_pip_dependencies(
+            venv_executable=venv_executable,
+            pip_dependencies=tuple(pip_dependencies)
+        )
+    # Define the decorator
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            # Serialize function arguments using cloudpickle
+            parent_conn, child_conn = multiprocessing.Pipe()
+            args = [cloudpickle.dumps(arg) for arg in args]
+            kwargs = {key: cloudpickle.dumps(value) for key, value in kwargs.items()}
+            pickleable_func_with_queue = PickleableFunctionWithPipeIO(func, child_conn, venv_executable)
+            # Start the context manager that will change the executable used by multiprocessing
+            with MultiprocessingExecutableContextManager(venv_executable):
+                # Create a new process that will run the Python code
+                process = multiprocessing.Process(target=pickleable_func_with_queue, args=args, kwargs=kwargs)
+                # Start the process
+                process.start()
+                # Fetch result from the child process
+                serialized_result = parent_conn.recv_bytes()
+                # Wait for the process to finish
+                process.join()
+            # Check if the process exited with an error
+            if process.exitcode != 0:
+                raise ChildProcessError(f"Process exited with code {process.exitcode}")
+            # Check if the serialized_result is empty
+            if not serialized_result:
+                raise RuntimeError(f"No result was returned for {func.__name__}")
+            # Deserialize the result using cloudpickle
+            return cloudpickle.loads(serialized_result)
+        return wrapper
+    return decorator

--- a/flojoy/flojoy_node_venv.py
+++ b/flojoy/flojoy_node_venv.py
@@ -112,7 +112,26 @@ def _get_venv_executable_path(venv_path: os.PathLike | str) -> os.PathLike | str
 def _get_venv_cache_dir():
     return os.path.join(FLOJOY_CACHE_DIR, "flojoy_node_venv")
 
-def run_in_venv(pip_dependencies=[], verbose=False):
+def run_in_venv(pip_dependencies: list[str] = [], verbose: bool =False):
+    """A decorator that allows a function to be executed in a virtual environment.
+    
+    Args:
+        pip_dependencies (list[str]): A list of pip dependencies to install into the virtual environment. Defaults to [].
+        verbose (bool): Whether to print the pip install output. Defaults to False.
+
+    Example usage:
+    ```python
+    from flojoy import flojoy, run_in_venv
+    
+    @flojoy
+    @run_in_venv(pip_dependencies=["torch==2.0.1", "torchvision==0.15.2"])
+    def TORCH_NODE(default: Matrix) -> Matrix:
+        import torch
+        import torchvision
+        # Do stuff with torch
+        ...
+        return Matrix(...)
+    """
     # Pre-pend flojoy and cloudpickle as mandatory pip dependencies
     packages_dict = {package.name: package.version for package in importlib.metadata.distributions()}
     pip_dependencies = sorted([

--- a/flojoy/flojoy_python.py
+++ b/flojoy/flojoy_python.py
@@ -5,7 +5,7 @@ import traceback
 from pathlib import Path
 from functools import wraps
 from .data_container import DataContainer
-from .utils import PlotlyJSONEncoder, dump_str
+from .utils import PlotlyJSONEncoder
 from typing import Callable, Any, Optional
 from .job_result_utils import get_frontend_res_obj_from_result, get_dc_from_result
 from .utils import send_to_socket

--- a/flojoy/utils.py
+++ b/flojoy/utils.py
@@ -1,3 +1,4 @@
+import sys
 import decimal
 import json as _json
 
@@ -23,6 +24,11 @@ __all__ = [
     "set_frontier_api_key",
     "set_frontier_s3_key",
 ]
+
+if sys.platform == "win32":
+    FLOJOY_CACHE_DIR = os.path.join(os.environ["APPDATA"], ".flojoy")
+else:
+    FLOJOY_CACHE_DIR = os.path.join(os.environ["HOME"], ".flojoy")
 
 env_vars = dotenv_values("../.env")
 port = env_vars.get("VITE_BACKEND_PORT", "8000")

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,3 +64,4 @@ uptime==3.0.1
 urllib3==1.26.15
 wrapt==1.15.0
 zope.interface==6.0
+cloudpickle==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "torch>=1.9",
         "torchvision>=0.10",
         "Pillow",
+        "cloudpickle"
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -17,7 +17,7 @@ def mock_tempdir():
     with patch("tempfile.tempdir", _test_tempdir):
         yield _test_tempdir
     # Clean up
-    # shutil.rmtree(_test_tempdir)
+    shutil.rmtree(_test_tempdir)
 
 
 def test_run_in_venv_imports_properly(mock_tempdir):
@@ -30,6 +30,7 @@ def test_run_in_venv_imports_properly(mock_tempdir):
         import sys
         import importlib.metadata
         import jax
+
         # Get the list of installed packages
         packages_dict = {package.name: package.version for package in importlib.metadata.distributions()}
         return packages_dict, sys.path, sys.executable

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -40,9 +40,9 @@ def test_run_in_venv_imports_properly(mock_tempdir):
     print("EXECUTABLE: ", sys_executable)
     print("SYS_PATH: ", sys_path)
     print("PACKAGES_DICT: ", packages_dict)
-    # # Test for executable
-    # assert sys_executable.startswith(mock_tempdir)
-    # # Test for sys.path
-    # assert sys_path[-1].startswith(mock_tempdir)
-    # # Test for package version
-    # assert packages_dict["jax"] == "0.4.13"
+    # Test for executable
+    assert sys_executable.startswith(mock_tempdir)
+    # Test for sys.path
+    assert sys_path[-1].startswith(mock_tempdir)
+    # Test for package version
+    assert packages_dict["jax"] == "0.4.13"

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -14,7 +14,7 @@ def mock_tempdir():
     shutil.rmtree(_test_tempdir, ignore_errors=True)
     os.makedirs(_test_tempdir)
     # Patch the tempfile.tempdir
-    with patch("tempfile.gettempdir", _test_tempdir):
+    with patch("tempfile.gettempdir", return_value=_test_tempdir):
         yield _test_tempdir
     # Clean up
     shutil.rmtree(_test_tempdir)

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -9,7 +9,9 @@ from flojoy import flojoy, run_in_venv
 # Define a fixture to patch tempfile.tempdir
 @pytest.fixture
 def mock_tempdir():
-    _test_tempdir = "/tmp/run_in_venv_tests"
+    import tempfile
+    _test_tempdir = os.path.join(tempfile.gettempdir(), "test_flojoy_node_venv")
+    del tempfile
     # Wipe the directory to be patched if it exists
     shutil.rmtree(_test_tempdir, ignore_errors=True)
     os.makedirs(_test_tempdir)

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -14,7 +14,7 @@ def mock_tempdir():
     shutil.rmtree(_test_tempdir, ignore_errors=True)
     os.makedirs(_test_tempdir)
     # Patch the tempfile.tempdir
-    with patch("tempfile.tempdir", _test_tempdir):
+    with patch("tempfile.gettempdir", _test_tempdir):
         yield _test_tempdir
     # Clean up
     shutil.rmtree(_test_tempdir)

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -17,27 +17,28 @@ def mock_tempdir():
     with patch("tempfile.tempdir", _test_tempdir):
         yield _test_tempdir
     # Clean up
-    shutil.rmtree(_test_tempdir)
+    # shutil.rmtree(_test_tempdir)
 
 
 def test_run_in_venv_imports_properly(mock_tempdir):
     """Test that run_in_venv imports properly a package specified in its pip_dependencies argument"""
 
     @run_in_venv(pip_dependencies=["jax[cpu]==0.4.13"])
-    def hello_world_jax():
+    def empty_function_with_jax():
         # Import jax to check if it is installed
-        import jax
         # Fetch the list of installed packages
-        import pkg_resources
-        packages = pkg_resources.working_set
-        packages_dict = {package.key: package.version for package in packages}
-        return packages_dict
-    
-    # Run the function
-    packages_dict = hello_world_jax()
-    assert packages_dict["jax"] == "0.4.13"
+        import sys
+        import importlib.metadata
+        import jax
+        # Get the list of installed packages
+        packages_dict = {package.name: package.version for package in importlib.metadata.distributions()}
+        return packages_dict, sys.path, sys.executable
 
-#TODO(roulbac): Add more tests for
-# 1 - Making sure the venv interpreter is separate from the parent process
-# 2 - Making sure that the sys.path of the venv is appropriate
-# 3 - Making sure that packages in the parent process are not available in the venv
+    # Run the function
+    packages_dict, sys_path, sys_executable = empty_function_with_jax()
+    # Test for executable
+    assert sys_executable.startswith(mock_tempdir)
+    # Test for sys.path
+    assert sys_path[-1].startswith(mock_tempdir)
+    # Test for package version
+    assert packages_dict["jax"] == "0.4.13"

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -37,9 +37,12 @@ def test_run_in_venv_imports_properly(mock_tempdir):
 
     # Run the function
     packages_dict, sys_path, sys_executable = empty_function_with_jax()
-    # Test for executable
-    assert sys_executable.startswith(mock_tempdir)
-    # Test for sys.path
-    assert sys_path[-1].startswith(mock_tempdir)
-    # Test for package version
-    assert packages_dict["jax"] == "0.4.13"
+    print("EXECUTABLE: ", sys_executable)
+    print("SYS_PATH: ", sys_path)
+    print("PACKAGES_DICT: ", packages_dict)
+    # # Test for executable
+    # assert sys_executable.startswith(mock_tempdir)
+    # # Test for sys.path
+    # assert sys_path[-1].startswith(mock_tempdir)
+    # # Test for package version
+    # assert packages_dict["jax"] == "0.4.13"

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 from flojoy import flojoy, run_in_venv
 
+pytestmark = pytest.mark.slow
+
 
 # Define a fixture to patch tempfile.tempdir
 @pytest.fixture
@@ -22,8 +24,8 @@ def mock_tempdir():
     shutil.rmtree(_test_tempdir)
 
 
-def test_run_in_venv_imports_properly(mock_tempdir):
-    """Test that run_in_venv imports properly a package specified in its pip_dependencies argument"""
+def test_run_in_venv_imports_jax_properly(mock_tempdir):
+    """Test that run_in_venv imports properly jax for example"""
 
     @run_in_venv(pip_dependencies=["jax[cpu]==0.4.13"])
     def empty_function_with_jax():
@@ -39,12 +41,56 @@ def test_run_in_venv_imports_properly(mock_tempdir):
 
     # Run the function
     packages_dict, sys_path, sys_executable = empty_function_with_jax()
-    print("EXECUTABLE: ", sys_executable)
-    print("SYS_PATH: ", sys_path)
-    print("PACKAGES_DICT: ", packages_dict)
     # Test for executable
     assert sys_executable.startswith(mock_tempdir)
     # Test for sys.path
     assert sys_path[-1].startswith(mock_tempdir)
     # Test for package version
     assert packages_dict["jax"] == "0.4.13"
+
+
+# Two more tests similar to the above but with flytekit and opencv-python-headless
+def test_run_in_venv_imports_flytekit_properly(mock_tempdir):
+    # Define a function that imports flytekit and returns its version
+    @run_in_venv(pip_dependencies=["flytekit==1.7.0"])
+    def empty_function_with_flytekit():
+        import sys
+        import importlib.metadata
+        import flytekit
+
+        # Get the list of installed packages
+        packages_dict = {package.name: package.version for package in importlib.metadata.distributions()}
+        return packages_dict, sys.path, sys.executable
+
+    # Run the function
+    packages_dict, sys_path, sys_executable = empty_function_with_flytekit()
+    # Test for executable
+    assert sys_executable.startswith(mock_tempdir)
+    # Test for sys.path
+    assert sys_path[-1].startswith(mock_tempdir)
+    # Test for package version
+    assert packages_dict["flytekit"] == "1.7.0"
+
+
+def test_run_in_venv_imports_opencv_properly(mock_tempdir):
+    # Define a function that imports opencv-python-headless and returns its version
+    @run_in_venv(pip_dependencies=["opencv-python-headless==4.7.0.72"])
+    def empty_function_with_opencv():
+        import sys
+        import importlib.metadata
+        import cv2
+
+        # Get the list of installed packages
+        packages_dict = {package.name: package.version for package in importlib.metadata.distributions()}
+        return packages_dict, sys.path, sys.executable
+    
+    # Run the function
+    packages_dict, sys_path, sys_executable = empty_function_with_opencv()
+    # Test for executable
+    assert sys_executable.startswith(mock_tempdir)
+    # Test for sys.path
+    assert sys_path[-1].startswith(mock_tempdir)
+    # Test for package version
+    assert packages_dict["opencv-python-headless"] == "4.7.0.72"
+
+

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -1,0 +1,43 @@
+import pytest
+import os
+import shutil
+from unittest.mock import patch
+
+from flojoy import flojoy, run_in_venv
+
+
+# Define a fixture to patch tempfile.tempdir
+@pytest.fixture
+def mock_tempdir():
+    _test_tempdir = "/tmp/run_in_venv_tests"
+    # Wipe the directory to be patched if it exists
+    shutil.rmtree(_test_tempdir, ignore_errors=True)
+    os.makedirs(_test_tempdir)
+    # Patch the tempfile.tempdir
+    with patch("tempfile.tempdir", _test_tempdir):
+        yield _test_tempdir
+    # Clean up
+    shutil.rmtree(_test_tempdir)
+
+
+def test_run_in_venv_imports_properly(mock_tempdir):
+    """Test that run_in_venv imports properly a package specified in its pip_dependencies argument"""
+
+    @run_in_venv(pip_dependencies=["jax[cpu]==0.4.13"])
+    def hello_world_jax():
+        # Import jax to check if it is installed
+        import jax
+        # Fetch the list of installed packages
+        import pkg_resources
+        packages = pkg_resources.working_set
+        packages_dict = {package.key: package.version for package in packages}
+        return packages_dict
+    
+    # Run the function
+    packages_dict = hello_world_jax()
+    assert packages_dict["jax"] == "0.4.13"
+
+#TODO(roulbac): Add more tests for
+# 1 - Making sure the venv interpreter is separate from the parent process
+# 2 - Making sure that the sys.path of the venv is appropriate
+# 3 - Making sure that packages in the parent process are not available in the venv


### PR DESCRIPTION
Essentially this decorator allows to execute functions in their own virtual environments that
are created for them on the fly. Those venvs are cached under `FLOJOY_CACHE_DIR` present in `utils`. All venvs will have `flojoy` and `cloudpickle` installed by default as mandatory requirements for this to function.

The decorator can be coupled with flojoy nodes as follows

```python
from flojoy import flojoy, run_in_venv

@flojoy
@run_in_venv(pip_dependencies=["torch==2.0.1", "torchvision==0.15.2"])
def TORCH_NODE(default: Matrix) -> Matrix:
    import torch
    import torchvision
    # Do stuff with torch
    ...
    return Matrix(...)
```


~TODO @roulbac:~

~Add automated github action tests for this decorator~