### PR TITLE
Prevent `@run_in_venv` from hanging if throws an error, pass child process exception

### DIFF
--- a/.github/workflows/test-flojoy-node-env.yaml
+++ b/.github/workflows/test-flojoy-node-env.yaml
@@ -31,6 +31,7 @@ jobs:
         run: |
           pip install ruff pytest
           pip install -r requirements.txt
+          pip install -e .
 
       - name: Run python tests
         run: python -m pytest -vv tests/flojoy_node_venv_test_.py --runslow  
@@ -50,6 +51,7 @@ jobs:
         run: |
           pip install ruff pytest
           pip install -r requirements.txt
+          pip install -e .
 
       - name: Run python tests
         run: python -m pytest -vv tests/flojoy_node_venv_test_.py --runslow  
@@ -70,6 +72,7 @@ jobs:
         run: |
           pip install ruff pytest
           pip install -r requirements.txt
+          pip install -e .
         shell: powershell
 
       - name: Run python tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,3 +59,4 @@ urllib3==1.26.15
 wrapt==1.15.0
 zope.interface==6.0
 cloudpickle==2.2.1
+huggingface-hub==0.16.4

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -56,7 +56,7 @@ def test_run_in_venv_imports_flytekit_properly(mock_venv_cache_dir):
     from flojoy import flojoy, run_in_venv
 
     # Define a function that imports flytekit and returns its version
-    @run_in_venv(pip_dependencies=["flytekit==1.7.0"])
+    @run_in_venv(pip_dependencies=["flytekit==1.6.2"])
     def empty_function_with_flytekit():
         import sys
         import importlib.metadata
@@ -73,7 +73,7 @@ def test_run_in_venv_imports_flytekit_properly(mock_venv_cache_dir):
     # Test for sys.path
     assert sys_path[-1].startswith(mock_venv_cache_dir)
     # Test for package version
-    assert packages_dict["flytekit"] == "1.7.0"
+    assert packages_dict["flytekit"] == "1.6.2"
 
 
 def test_run_in_venv_imports_opencv_properly(mock_venv_cache_dir):

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -101,3 +101,16 @@ def test_run_in_venv_imports_opencv_properly(mock_venv_cache_dir):
     assert packages_dict["opencv-python-headless"] == "4.7.0.72"
 
 
+
+def test_run_in_venv_does_not_hang_on_error(mock_venv_cache_dir):
+    """Test that run_in_venv imports properly jax for example"""
+
+    from flojoy import run_in_venv
+
+    @run_in_venv(pip_dependencies=[])
+    def empty_function_with_error():
+        return 1/0
+
+    # Run the function and excpect an error
+    with pytest.raises(ZeroDivisionError):
+        empty_function_with_error()

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -111,6 +111,6 @@ def test_run_in_venv_does_not_hang_on_error(mock_venv_cache_dir):
     def empty_function_with_error():
         return 1/0
 
-    # Run the function and excpect an error
+    # Run the function and expect an error
     with pytest.raises(ZeroDivisionError):
         empty_function_with_error()

--- a/tests/flojoy_node_venv_test_.py
+++ b/tests/flojoy_node_venv_test_.py
@@ -49,31 +49,33 @@ def test_run_in_venv_imports_jax_properly(mock_venv_cache_dir):
     # Test for package version
     assert packages_dict["jax"] == "0.4.13"
 
+# TODO(roulbac): Fix this test once this bug-fix is applied to the next flyte release
+# link: https://github.com/flyteorg/flytekit/pull/1746
 
-# Two more tests similar to the above but with flytekit and opencv-python-headless
-def test_run_in_venv_imports_flytekit_properly(mock_venv_cache_dir):
-    
-    from flojoy import flojoy, run_in_venv
-
-    # Define a function that imports flytekit and returns its version
-    @run_in_venv(pip_dependencies=["flytekit==1.6.2"])
-    def empty_function_with_flytekit():
-        import sys
-        import importlib.metadata
-        import flytekit
-
-        # Get the list of installed packages
-        packages_dict = {package.name: package.version for package in importlib.metadata.distributions()}
-        return packages_dict, sys.path, sys.executable
-
-    # Run the function
-    packages_dict, sys_path, sys_executable = empty_function_with_flytekit()
-    # Test for executable
-    assert sys_executable.startswith(mock_venv_cache_dir)
-    # Test for sys.path
-    assert sys_path[-1].startswith(mock_venv_cache_dir)
-    # Test for package version
-    assert packages_dict["flytekit"] == "1.6.2"
+# # Two more tests similar to the above but with flytekit and opencv-python-headless
+# def test_run_in_venv_imports_flytekit_properly(mock_venv_cache_dir):
+#     
+#     from flojoy import flojoy, run_in_venv
+# 
+#     # Define a function that imports flytekit and returns its version
+#     @run_in_venv(pip_dependencies=["flytekit==1.8.0"])
+#     def empty_function_with_flytekit():
+#         import sys
+#         import importlib.metadata
+#         import flytekit
+# 
+#         # Get the list of installed packages
+#         packages_dict = {package.name: package.version for package in importlib.metadata.distributions()}
+#         return packages_dict, sys.path, sys.executable
+# 
+#     # Run the function
+#     packages_dict, sys_path, sys_executable = empty_function_with_flytekit()
+#     # Test for executable
+#     assert sys_executable.startswith(mock_venv_cache_dir)
+#     # Test for sys.path
+#     assert sys_path[-1].startswith(mock_venv_cache_dir)
+#     # Test for package version
+#     assert packages_dict["flytekit"] == "1.8.0"
 
 
 def test_run_in_venv_imports_opencv_properly(mock_venv_cache_dir):


### PR DESCRIPTION
When things go wrong, the child process can hang without returning an exception.
This PR fixes the issue with a try/catch

Additionally, added a few missing elements to the CI pip install step.

P.S: Omitting the `flytekit` test since `flytekit` itself broke as of yesterday (see comment above the test code)